### PR TITLE
Handle different gpio groups for trigger and echo

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -682,11 +682,13 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
 #endif
 
 #ifdef SONAR
-        if (init->sonarGPIOConfig && timerHardwarePtr->gpio == init->sonarGPIOConfig->gpio &&
-            (
-                timerHardwarePtr->pin == init->sonarGPIOConfig->triggerPin ||
-                timerHardwarePtr->pin == init->sonarGPIOConfig->echoPin
-            )
+        if (init->sonarGPIOConfig &&
+          (
+            (timerHardwarePtr->gpio == init->sonarGPIOConfig->triggerGPIO
+               && timerHardwarePtr->pin == init->sonarGPIOConfig->triggerPin) ||
+            (timerHardwarePtr->gpio == init->sonarGPIOConfig->echoGPIO
+               && timerHardwarePtr->pin == init->sonarGPIOConfig->echoPin)
+          )
         ) {
             continue;
         }

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -47,8 +47,9 @@
 
 
 typedef struct sonarGPIOConfig_s {
-    GPIO_TypeDef *gpio;
+    GPIO_TypeDef *triggerGPIO;
     uint16_t triggerPin;
+    GPIO_TypeDef *echoGPIO;
     uint16_t echoPin;
 } sonarGPIOConfig_t;
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -331,9 +331,10 @@ void init(void)
     sonarGPIOConfig_t sonarGPIOConfig;
     if (feature(FEATURE_SONAR)) {
         sonarHardware = sonarGetHardwareConfiguration(masterConfig.batteryConfig.currentMeterType);
-        sonarGPIOConfig.gpio = SONAR_GPIO;
-        sonarGPIOConfig.triggerPin = sonarHardware->echo_pin;
-        sonarGPIOConfig.echoPin = sonarHardware->trigger_pin;
+        sonarGPIOConfig.triggerGPIO = sonarHardware->trigger_gpio;
+        sonarGPIOConfig.triggerPin = sonarHardware->trigger_pin;
+        sonarGPIOConfig.echoGPIO = sonarHardware->echo_gpio;
+        sonarGPIOConfig.echoPin = sonarHardware->echo_pin;
         pwm_params.sonarGPIOConfig = &sonarGPIOConfig;
     }
 #endif


### PR DESCRIPTION
pwm_mapping.h: Expanded sonarGPIOconfig_t to accommodate two GPIO_TypeDefs, one for trigger and another for echo.
pwm_mapping.c & main.c: Modded to use the expanded sonarGPIOConfig_t.