### PR TITLE
Split OLED displayport out of dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,7 @@ HIGHEND_SRC = \
             flight/gps_conversion.c \
             io/gps.c \
             io/ledstrip.c \
+            io/displayport_oled.c \
             io/dashboard.c \
             sensors/sonar.c \
             sensors/barometer.c \

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -29,6 +29,7 @@ void displayClear(displayPort_t *instance)
     instance->vTable->clear(instance);
     instance->cleared = true;
     instance->cursorRow = -1;
+    instance->inCMS = false;
 }
 
 void displayOpen(displayPort_t *instance)

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -26,6 +26,7 @@ typedef struct displayPort_s {
     // CMS state
     bool cleared;
     int8_t cursorRow;
+    bool inCMS;
 } displayPort_t;
 
 typedef struct displayPortVTable_s {

--- a/src/main/io/cms.c
+++ b/src/main/io/cms.c
@@ -86,10 +86,9 @@ void cmsx_FeatureWriteback(void);
 #define CMS_MAX_DEVICE 4
 #endif
 
-cmsDeviceInitFuncPtr cmsDeviceInitFunc[CMS_MAX_DEVICE];
-int cmsDeviceCount;
-int cmsCurrentDevice = -1;
-int cmsLastDevice = -1;
+static cmsDeviceInitFuncPtr cmsDeviceInitFunc[CMS_MAX_DEVICE];
+static int cmsDeviceCount;
+static int cmsCurrentDevice = -1;
 
 bool cmsDeviceRegister(cmsDeviceInitFuncPtr func)
 {
@@ -101,7 +100,7 @@ bool cmsDeviceRegister(cmsDeviceInitFuncPtr func)
     return true;
 }
 
-cmsDeviceInitFuncPtr cmsDeviceSelectCurrent(void)
+static cmsDeviceInitFuncPtr cmsDeviceSelectCurrent(void)
 {
     if (cmsDeviceCount == 0)
         return NULL;
@@ -112,7 +111,7 @@ cmsDeviceInitFuncPtr cmsDeviceSelectCurrent(void)
     return cmsDeviceInitFunc[cmsCurrentDevice];
 }
 
-cmsDeviceInitFuncPtr cmsDeviceSelectNext(void)
+static cmsDeviceInitFuncPtr cmsDeviceSelectNext(void)
 {
     if (cmsDeviceCount == 0)
         return NULL;
@@ -124,7 +123,7 @@ cmsDeviceInitFuncPtr cmsDeviceSelectNext(void)
 
 #define CMS_UPDATE_INTERVAL 50 // msec
 
-void cmsScreenInit(displayPort_t *pDisp, cmsDeviceInitFuncPtr cmsDeviceInitFunc)
+static void cmsScreenInit(displayPort_t *pDisp, cmsDeviceInitFuncPtr cmsDeviceInitFunc)
 {
     cmsDeviceInitFunc(pDisp);
 }
@@ -150,23 +149,23 @@ void cmsScreenInit(displayPort_t *pDisp, cmsDeviceInitFuncPtr cmsDeviceInitFunc)
 #define RIGHT_MENU_COLUMN(p) ((p)->cols - 8)
 #define MAX_MENU_ITEMS(p)    ((p)->rows - 2)
 
-displayPort_t currentDisplay;
+static displayPort_t currentDisplay;
 
-bool cmsInMenu = false;
+static bool cmsInMenu = false;
 
 OSD_Entry menuMain[];
 
 // XXX Does menu backing support backing into second page???
 
-OSD_Entry *menuStack[10];        // Stack to save menu transition
-uint8_t menuStackHistory[10];    // cursorRow in a stacked menu
-uint8_t menuStackIdx = 0;
+static OSD_Entry *menuStack[10];        // Stack to save menu transition
+static uint8_t menuStackHistory[10];    // cursorRow in a stacked menu
+static uint8_t menuStackIdx = 0;
 
-OSD_Entry *currentMenu;          // Points to top entry of the current page
-OSD_Entry *nextPage;             // Only 2 pages are allowed (for now)
-uint8_t maxRow;                  // Max row in a page
+static OSD_Entry *currentMenu;          // Points to top entry of the current page
+static OSD_Entry *nextPage;             // Only 2 pages are allowed (for now)
+static uint8_t maxRow;                  // Max row in a page
 
-int8_t cursorRow;
+static int8_t cursorRow;
 
 // Stick/key detection
 
@@ -185,7 +184,7 @@ int8_t cursorRow;
 #define BUTTON_TIME   250 // msec
 #define BUTTON_PAUSE  500 // msec
 
-void cmsUpdateMaxRow(displayPort_t *instance)
+static void cmsUpdateMaxRow(displayPort_t *instance)
 {
     OSD_Entry *ptr;
 
@@ -242,7 +241,7 @@ void cmsPadToSize(char *buf, int size)
     buf[size] = 0;
 }
 
-int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row, bool drawPolled)
+static int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row, bool drawPolled)
 {
     char buff[10];
     int cnt = 0;
@@ -360,7 +359,7 @@ int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row, bool dr
     return cnt;
 }
 
-void cmsDrawMenu(displayPort_t *pDisplay)
+static void cmsDrawMenu(displayPort_t *pDisplay)
 {
     uint8_t i;
     OSD_Entry *p;
@@ -464,7 +463,7 @@ long cmsMenuChange(displayPort_t *pDisplay, void *ptr)
     return 0;
 }
 
-long cmsMenuBack(displayPort_t *pDisplay)
+static long cmsMenuBack(displayPort_t *pDisplay)
 {
     // becasue pids and rates may be stored in profiles we need some thicks to manipulate it
     // hack to save pid profile
@@ -487,7 +486,7 @@ long cmsMenuBack(displayPort_t *pDisplay)
     return 0;
 }
 
-void cmsMenuOpen(void)
+static void cmsMenuOpen(void)
 {
     cmsDeviceInitFuncPtr initfunc;
 
@@ -541,7 +540,7 @@ long cmsMenuExit(displayPort_t *pDisplay, void *ptr)
     return 0;
 }
 
-uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
+static uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
 {
     uint16_t res = BUTTON_TIME;
     OSD_Entry *p;
@@ -714,7 +713,7 @@ uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
     return res;
 }
 
-void cmsUpdate(displayPort_t *pDisplay, uint32_t currentTime)
+static void cmsUpdate(displayPort_t *pDisplay, uint32_t currentTime)
 {
     static int16_t rcDelay = BUTTON_TIME;
     static uint32_t lastCalled = 0;
@@ -808,7 +807,7 @@ static char infoTargetName[] = __TARGET__;
 
 #include "msp/msp_protocol.h" // XXX for FC identification... not available elsewhere
 
-OSD_Entry menuInfo[] = {
+static OSD_Entry menuInfo[] = {
     { "--- INFO ---", OME_Label, NULL, NULL, 0 },
     { "FWID", OME_String, NULL, BETAFLIGHT_IDENTIFIER, 0 },
     { "FWVER", OME_String, NULL, FC_VERSION_STRING, 0 },
@@ -830,7 +829,7 @@ void cmsx_InfoInit(void)
 
 // Features
 
-OSD_Entry menuFeatures[] =
+static OSD_Entry menuFeatures[] =
 {
     {"--- FEATURES ---", OME_Label, NULL, NULL, 0},
     {"BLACKBOX", OME_Submenu, cmsMenuChange, cmsx_menuBlackbox, 0},

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -31,6 +31,7 @@
 #include "build/build_config.h"
 
 #include "drivers/system.h"
+#include "drivers/display.h"
 #include "drivers/display_ug2864hsweg01.h"
 
 #include "common/printf.h"
@@ -53,10 +54,9 @@
 #include "flight/failsafe.h"
 
 #include "io/cms.h"
+#include "io/displayport_oled.h"
 
-#ifdef CMS
-void dashboardCmsInit(displayPort_t *pPort); // Forward
-#endif
+displayPort_t *displayPort;
 
 #ifdef GPS
 #include "io/gps.h"
@@ -585,17 +585,14 @@ void showDebugPage(void)
 }
 #endif
 
-#ifdef OLEDCMS
-static bool dashboardInCMS = false;
-#endif
-
 void dashboardUpdate(uint32_t currentTime)
 {
     static uint8_t previousArmedState = 0;
 
 #ifdef OLEDCMS
-    if (dashboardInCMS)
+    if (displayPort && displayPort->inCMS) {
         return;
+    }
 #endif
 
     const bool updateNow = (int32_t)(currentTime - nextDisplayUpdateAt) >= 0L;
@@ -703,6 +700,12 @@ void dashboardSetPage(pageId_e pageId)
     pageState.pageFlags |= PAGE_STATE_FLAG_FORCE_PAGE_CHANGE;
 }
 
+void dashboardCmsInit(displayPort_t *displayPortToUse)
+{
+    displayPort = displayPortToUse;
+    displayPortOledInit(displayPort);
+}
+
 void dashboardInit(rxConfig_t *rxConfigToUse)
 {
     delay(200);
@@ -749,76 +752,4 @@ void dashboardDisablePageCycling(void)
 {
     pageState.pageFlags &= ~PAGE_STATE_FLAG_CYCLE_ENABLED;
 }
-
-#ifdef OLEDCMS
-#include "drivers/display.h"
-
-static int dashboardBegin(displayPort_t *displayPort)
-{
-    UNUSED(displayPort);
-    dashboardInCMS = true;
-
-    return 0;
-}
-
-static int dashboardEnd(displayPort_t *displayPort)
-{
-    UNUSED(displayPort);
-    dashboardInCMS = false;
-
-    return 0;
-}
-
-static int dashboardClear(displayPort_t *displayPort)
-{
-    UNUSED(displayPort);
-    i2c_OLED_clear_display_quick();
-
-    return 0;
-}
-
-static int dashboardWrite(displayPort_t *displayPort, uint8_t x, uint8_t y, char *s)
-{
-    UNUSED(displayPort);
-    i2c_OLED_set_xy(x, y);
-    i2c_OLED_send_string(s);
-
-    return 0;
-}
-
-static int dashboardHeartbeat(displayPort_t *displayPort)
-{
-    UNUSED(displayPort);
-    return 0;
-}
-
-static void dashboardResync(displayPort_t *displayPort)
-{
-    UNUSED(displayPort);
-}
-
-static uint32_t dashboardTxBytesFree(displayPort_t *displayPort)
-{
-    UNUSED(displayPort);
-    return UINT32_MAX;
-}
-
-static const displayPortVTable_t dashboardVTable = {
-    dashboardBegin,
-    dashboardEnd,
-    dashboardClear,
-    dashboardWrite,
-    dashboardHeartbeat,
-    dashboardResync,
-    dashboardTxBytesFree,
-};
-
-void dashboardCmsInit(displayPort_t *displayPort)
-{
-    displayPort->rows = SCREEN_CHARACTER_ROW_COUNT;
-    displayPort->cols = SCREEN_CHARACTER_COLUMN_COUNT;
-    displayPort->vTable = &dashboardVTable;
-}
-#endif // OLEDCMS
-
 #endif // USE_DASHBOARD

--- a/src/main/io/displayport_oled.c
+++ b/src/main/io/displayport_oled.c
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef OLEDCMS
+
+#include "common/utils.h"
+
+#include "drivers/display.h"
+#include "drivers/display_ug2864hsweg01.h"
+
+#include "io/displayport_oled.h"
+
+static int oledOpen(displayPort_t *displayPort)
+{
+    displayPort->inCMS = true;
+    return 0;
+}
+
+static int oledClose(displayPort_t *displayPort)
+{
+    displayPort->inCMS = false;
+    return 0;
+}
+
+static int oledClear(displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    i2c_OLED_clear_display_quick();
+    return 0;
+}
+
+static int oledWrite(displayPort_t *displayPort, uint8_t x, uint8_t y, char *s)
+{
+    UNUSED(displayPort);
+    i2c_OLED_set_xy(x, y);
+    i2c_OLED_send_string(s);
+    return 0;
+}
+
+static int oledHeartbeat(displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return 0;
+}
+
+static void oledResync(displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+}
+
+static uint32_t oledTxBytesFree(displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return UINT32_MAX;
+}
+
+static const displayPortVTable_t oledVTable = {
+    .open = oledOpen,
+    .close = oledClose,
+    .clear = oledClear,
+    .write = oledWrite,
+    .heartbeat = oledHeartbeat,
+    .resync = oledResync,
+    .txBytesFree = oledTxBytesFree
+};
+
+void displayPortOledInit(displayPort_t *displayPort)
+{
+    displayPort->vTable = &oledVTable;
+    displayPort->rows = SCREEN_CHARACTER_ROW_COUNT;
+    displayPort->cols = SCREEN_CHARACTER_COLUMN_COUNT;
+}
+#endif // OLEDCMS

--- a/src/main/io/displayport_oled.h
+++ b/src/main/io/displayport_oled.h
@@ -15,33 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define ENABLE_DEBUG_DASHBOARD_PAGE
+#pragma once
 
-typedef enum {
-    PAGE_WELCOME,
-    PAGE_ARMED,
-    PAGE_BATTERY,
-    PAGE_SENSORS,
-    PAGE_RX,
-    PAGE_PROFILE,
-#ifndef SKIP_TASK_STATISTICS
-    PAGE_TASKS,
-#endif
-#ifdef GPS
-    PAGE_GPS,
-#endif
-#ifdef ENABLE_DEBUG_DASHBOARD_PAGE
-    PAGE_DEBUG,
-#endif
-} pageId_e;
-
-struct rxConfig_s;
-void dashboardInit(struct rxConfig_s *intialRxConfig);
-void dashboardUpdate(uint32_t currentTime);
-
-void dashboardShowFixedPage(pageId_e pageId);
-
-void dashboardEnablePageCycling(void);
-void dashboardDisablePageCycling(void);
-void dashboardResetPageCycling(void);
-void dashboardSetNextPageChangeAt(uint32_t futureMicros);
+struct displayPort_s;
+void displayPortOledInit(struct displayPort_s *displayPort);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -29,9 +29,9 @@
 
 #include "platform.h"
 
-#include "build/version.h"
-
 #ifdef OSD
+
+#include "build/version.h"
 
 #include "common/utils.h"
 


### PR DESCRIPTION
I've split the OLED displayport code out of `dashboard.c`. As part of that I've changed the `dashboardCmsInit` code, but I haven't got a wired up OLED display at the moment, so I haven't been able to test that. It should be fine, bug could you just check it before you merge?

I've also made a bunch of functions and variables in `cms.c` static.