### PR TITLE
Code tidy and addition of GPL headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,10 +560,19 @@ HIGHEND_SRC = \
             flight/gtune.c \
             flight/navigation.c \
             flight/gps_conversion.c \
-            io/gps.c \
-            io/ledstrip.c \
+            io/canvas.c \
+            io/cms.c \
+            io/cms_builtin.c \
+            io/cms_imu.c \
+            io/cms_blackbox.c \
+            io/cms_vtx.c \
+            io/cms_ledstrip.c \
             io/displayport_oled.c \
             io/dashboard.c \
+            io/gps.c \
+            io/ledstrip.c \
+            io/osd.c \
+            io/osd_max7456.c \
             sensors/sonar.c \
             sensors/barometer.c \
             telemetry/telemetry.c \

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -35,16 +35,25 @@ void displayOpen(displayPort_t *instance)
 {
     instance->vTable->open(instance);
     instance->vTable->clear(instance);
-    instance->inCMS = true;
+    instance->isOpen = true;
 }
 
 void displayClose(displayPort_t *instance)
 {
     instance->vTable->close(instance);
-    instance->inCMS = false;
+    instance->isOpen = false;
 }
 
-int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, char *s)
+bool displayIsOpen(const displayPort_t *instance)
+{
+    if (instance && instance->isOpen) { // can be called before initialised
+        return true;
+    } else {
+        return false;
+    }
+}
+
+int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, const char *s)
 {
     return instance->vTable->write(instance, x, y, s);
 }
@@ -59,7 +68,7 @@ void displayResync(displayPort_t *instance)
     instance->vTable->resync(instance);
 }
 
-uint16_t displayTxBytesFree(displayPort_t *instance)
+uint16_t displayTxBytesFree(const displayPort_t *instance)
 {
     return instance->vTable->txBytesFree(instance);
 }

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -26,23 +26,24 @@ typedef struct displayPort_s {
     // CMS state
     bool cleared;
     int8_t cursorRow;
-    bool inCMS;
+    bool isOpen;
 } displayPort_t;
 
 typedef struct displayPortVTable_s {
     int (*open)(displayPort_t *displayPort);
     int (*close)(displayPort_t *displayPort);
     int (*clear)(displayPort_t *displayPort);
-    int (*write)(displayPort_t *displayPort, uint8_t col, uint8_t row, char *text);
+    int (*write)(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *text);
     int (*heartbeat)(displayPort_t *displayPort);
     void (*resync)(displayPort_t *displayPort);
-    uint32_t (*txBytesFree)(displayPort_t *displayPort);
+    uint32_t (*txBytesFree)(const displayPort_t *displayPort);
 } displayPortVTable_t;
 
 void displayOpen(displayPort_t *instance);
 void displayClose(displayPort_t *instance);
+bool displayIsOpen(const displayPort_t *instance);
 void displayClear(displayPort_t *instance);
-int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, char *s);
+int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, const char *s);
 void displayHeartbeat(displayPort_t *instance);
 void displayResync(displayPort_t *instance);
-uint16_t displayTxBytesFree(displayPort_t *instance);
+uint16_t displayTxBytesFree(const displayPort_t *instance);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -294,7 +294,7 @@ void max7456WriteChar(uint8_t x, uint8_t y, uint8_t c)
 	screenBuffer[y*30+x] = c;
 }
 
-void max7456Write(uint8_t x, uint8_t y, char *buff)
+void max7456Write(uint8_t x, uint8_t y, const char *buff)
 {
 	uint8_t i = 0;
 	for (i = 0; *(buff+i); i++)
@@ -387,7 +387,7 @@ void max7456RefreshAll(void)
     }
 }
 
-void max7456WriteNvm(uint8_t char_address, uint8_t *font_data)
+void max7456WriteNvm(uint8_t char_address, const uint8_t *font_data)
 {
     uint8_t x;
 

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -146,9 +146,9 @@ extern uint16_t maxScreenSize;
 
 void    max7456Init(uint8_t system);
 void    max7456DrawScreen(void);
-void    max7456WriteNvm(uint8_t char_address, uint8_t *font_data);
+void    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
 uint8_t max7456GetRowsCount(void);
-void    max7456Write(uint8_t x, uint8_t y, char *buff);
+void    max7456Write(uint8_t x, uint8_t y, const char *buff);
 void    max7456WriteChar(uint8_t x, uint8_t y, uint8_t c);
 void    max7456ClearScreen(void);
 void    max7456RefreshAll(void);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1010,7 +1010,7 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         sbufWriteU16(dst, masterConfig.osdProfile.time_alarm);
         sbufWriteU16(dst, masterConfig.osdProfile.alt_alarm);
 
-        for (i = 0; i < OSD_MAX_ITEMS; i++) {
+        for (i = 0; i < OSD_ITEM_COUNT; i++) {
             sbufWriteU16(dst, masterConfig.osdProfile.item_pos[i]);
         }
 #else

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -40,13 +40,11 @@
 #include "flight/pid.h"
 #include "flight/altitudehold.h"
 
-#include "io/cms.h"
-
 #include "io/beeper.h"
+#include "io/cms.h"
 #include "io/dashboard.h"
 #include "io/gps.h"
 #include "io/ledstrip.h"
-#include "io/cms.h"
 #include "io/osd.h"
 #include "io/serial.h"
 #include "io/serial_cli.h"

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -40,8 +40,6 @@
 #include "fc/rc_curves.h"
 #include "fc/runtime_config.h"
 
-#include "io/cms.h"
-
 #include "io/gps.h"
 #include "io/beeper.h"
 #include "io/motors.h"

--- a/src/main/io/canvas.c
+++ b/src/main/io/canvas.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -22,47 +39,47 @@
 
 static displayPort_t canvasDisplayPort;
 
-static int canvasOutput(displayPort_t *displayPort, uint8_t cmd, uint8_t *buf, int len)
+static int canvasOutput(displayPort_t *displayPort, uint8_t cmd, const uint8_t *buf, int len)
 {
     UNUSED(displayPort);
-    mspSerialPush(cmd, buf, len);
-
-    return 6 + len;
+    return mspSerialPush(cmd, buf, len);
 }
 
-static int canvasBegin(displayPort_t *displayPort)
+static int canvasOpen(displayPort_t *displayPort)
 {
-    uint8_t subcmd[] = { 0 };
+    const uint8_t subcmd[] = { 0 };
 
     return canvasOutput(displayPort, MSP_CANVAS, subcmd, sizeof(subcmd));
 }
 
 static int canvasHeartBeat(displayPort_t *displayPort)
 {
-    return canvasBegin(displayPort);
+    return canvasOpen(displayPort);
 }
 
-static int canvasEnd(displayPort_t *displayPort)
+static int canvasClose(displayPort_t *displayPort)
 {
-    uint8_t subcmd[] = { 1 };
+    const uint8_t subcmd[] = { 1 };
 
     return canvasOutput(displayPort, MSP_CANVAS, subcmd, sizeof(subcmd));
 }
 
 static int canvasClear(displayPort_t *displayPort)
 {
-    uint8_t subcmd[] = { 2 };
+    const uint8_t subcmd[] = { 2 };
 
     return canvasOutput(displayPort, MSP_CANVAS, subcmd, sizeof(subcmd));
 }
 
-static int canvasWrite(displayPort_t *displayPort, uint8_t col, uint8_t row, char *string)
+static int canvasWrite(displayPort_t *displayPort, uint8_t col, uint8_t row, const char *string)
 {
-    int len;
-    uint8_t buf[30 + 4];
+#define MSP_CANVAS_MAX_STRING_LENGTH 30
+    uint8_t buf[MSP_CANVAS_MAX_STRING_LENGTH + 4];
 
-    if ((len = strlen(string)) >= 30)
-        len = 30;
+    int len = strlen(string);
+    if (len >= MSP_CANVAS_MAX_STRING_LENGTH) {
+        len = MSP_CANVAS_MAX_STRING_LENGTH;
+    }
 
     buf[0] = 3;
     buf[1] = row;
@@ -79,27 +96,27 @@ static void canvasResync(displayPort_t *displayPort)
     displayPort->cols = 30;
 }
 
-static uint32_t canvasTxBytesFree(displayPort_t *displayPort)
+static uint32_t canvasTxBytesFree(const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
     return mspSerialTxBytesFree();
 }
 
 static const displayPortVTable_t canvasVTable = {
-    canvasBegin,
-    canvasEnd,
-    canvasClear,
-    canvasWrite,
-    canvasHeartBeat,
-    canvasResync,
-    canvasTxBytesFree,
+    .open = canvasOpen,
+    .close = canvasClose,
+    .clear = canvasClear,
+    .write = canvasWrite,
+    .heartbeat = canvasHeartBeat,
+    .resync = canvasResync,
+    .txBytesFree = canvasTxBytesFree
 };
 
-void canvasInit()
+displayPort_t *canvasInit(void)
 {
     canvasDisplayPort.vTable = &canvasVTable;
-    canvasDisplayPort.inCMS = false;
+    canvasDisplayPort.isOpen = false;
     canvasResync(&canvasDisplayPort);
-    cmsDisplayPortRegister(&canvasDisplayPort);
+    return &canvasDisplayPort;
 }
 #endif

--- a/src/main/io/canvas.h
+++ b/src/main/io/canvas.h
@@ -1,3 +1,21 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
-void canvasInit(void);
-void canvasCmsInit(displayPort_t *dPort);
+
+struct displayPort_s;
+struct displayPort_s *canvasInit(void);

--- a/src/main/io/cms_blackbox.c
+++ b/src/main/io/cms_blackbox.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 //
 // CMS things for blackbox and flashfs.
 // 

--- a/src/main/io/cms_blackbox.h
+++ b/src/main/io/cms_blackbox.h
@@ -1,1 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
 extern CMS_Menu cmsx_menuBlackbox;

--- a/src/main/io/cms_builtin.c
+++ b/src/main/io/cms_builtin.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 //
 // Built-in menu contents and support functions
 //

--- a/src/main/io/cms_builtin.h
+++ b/src/main/io/cms_builtin.h
@@ -1,1 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
 extern CMS_Menu menuMain;

--- a/src/main/io/cms_imu.c
+++ b/src/main/io/cms_imu.c
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // Menu contents for PID, RATES, RC preview, misc
 // Should be part of the relevant .c file.

--- a/src/main/io/cms_imu.h
+++ b/src/main/io/cms_imu.h
@@ -1,1 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
 extern CMS_Menu cmsx_menuImu;

--- a/src/main/io/cms_ledstrip.c
+++ b/src/main/io/cms_ledstrip.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/main/io/cms_ledstrip.h
+++ b/src/main/io/cms_ledstrip.h
@@ -1,1 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
 extern CMS_Menu cmsx_menuLedstrip;

--- a/src/main/io/cms_osd.h
+++ b/src/main/io/cms_osd.h
@@ -1,2 +1,21 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
 extern CMS_Menu cmsx_menuAlarms;
 extern CMS_Menu cmsx_menuOsdLayout;

--- a/src/main/io/cms_types.h
+++ b/src/main/io/cms_types.h
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 //
 // Menu element types
 // XXX Upon separation, all OME would be renamed to CME_ or similar.

--- a/src/main/io/cms_vtx.c
+++ b/src/main/io/cms_vtx.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <ctype.h>

--- a/src/main/io/cms_vtx.h
+++ b/src/main/io/cms_vtx.h
@@ -1,1 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
 extern CMS_Menu cmsx_menuVtx;

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -83,6 +83,7 @@ static uint32_t nextDisplayUpdateAt = 0;
 static bool dashboardPresent = false;
 
 static rxConfig_t *rxConfig;
+static displayPort_t *displayPort;
 
 #define PAGE_TITLE_LINE_COUNT 1
 
@@ -588,7 +589,7 @@ void dashboardUpdate(uint32_t currentTime)
     static uint8_t previousArmedState = 0;
 
 #ifdef OLEDCMS
-    if (oledDisplayPort.inCMS) {
+    if (displayIsOpen(displayPort)) {
         return;
     }
 #endif
@@ -704,8 +705,9 @@ void dashboardInit(rxConfig_t *rxConfigToUse)
     resetDisplay();
     delay(200);
 
+    displayPort = displayPortOledInit();
 #if defined(CMS) && defined(OLEDCMS)
-    displayPortOledInit();
+    cmsDisplayPortRegister(displayPort);
 #endif
 
     rxConfig = rxConfigToUse;

--- a/src/main/io/displayport_oled.c
+++ b/src/main/io/displayport_oled.c
@@ -20,18 +20,12 @@
 
 #include "platform.h"
 
-#ifdef OLEDCMS
-
 #include "common/utils.h"
 
 #include "drivers/display.h"
 #include "drivers/display_ug2864hsweg01.h"
 
-#include "io/cms.h"
-#include "io/displayport_oled.h"
-
-// Exported
-displayPort_t oledDisplayPort;
+static displayPort_t oledDisplayPort;
 
 static int oledOpen(displayPort_t *displayPort)
 {
@@ -52,7 +46,7 @@ static int oledClear(displayPort_t *displayPort)
     return 0;
 }
 
-static int oledWrite(displayPort_t *displayPort, uint8_t x, uint8_t y, char *s)
+static int oledWrite(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *s)
 {
     UNUSED(displayPort);
     i2c_OLED_set_xy(x, y);
@@ -71,7 +65,7 @@ static void oledResync(displayPort_t *displayPort)
     UNUSED(displayPort);
 }
 
-static uint32_t oledTxBytesFree(displayPort_t *displayPort)
+static uint32_t oledTxBytesFree(const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
     return UINT32_MAX;
@@ -87,13 +81,11 @@ static const displayPortVTable_t oledVTable = {
     .txBytesFree = oledTxBytesFree
 };
 
-void displayPortOledInit()
+displayPort_t *displayPortOledInit(void)
 {
     oledDisplayPort.vTable = &oledVTable;
     oledDisplayPort.rows = SCREEN_CHARACTER_ROW_COUNT;
     oledDisplayPort.cols = SCREEN_CHARACTER_COLUMN_COUNT;
-    oledDisplayPort.inCMS = false;
-
-    cmsDisplayPortRegister(&oledDisplayPort);
+    oledDisplayPort.isOpen = false;
+    return &oledDisplayPort;
 }
-#endif // OLEDCMS

--- a/src/main/io/displayport_oled.h
+++ b/src/main/io/displayport_oled.h
@@ -17,6 +17,4 @@
 
 #pragma once
 
-void displayPortOledInit(void);
-
-extern displayPort_t oledDisplayPort;
+displayPort_t *displayPortOledInit(void);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -38,8 +38,6 @@
 
 #include "sensors/sensors.h"
 
-#include "io/cms.h"
-
 #include "io/serial.h"
 #include "io/dashboard.h"
 #include "io/gps.h"

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -34,16 +34,16 @@ typedef enum {
     OSD_GPS_SPEED,
     OSD_GPS_SATS,
     OSD_ALTITUDE,
-    OSD_MAX_ITEMS, // MUST BE LAST
-} osd_items_t;
+    OSD_ITEM_COUNT // MUST BE LAST
+} osd_items_e;
 
 typedef enum {
     OSD_UNIT_IMPERIAL,
     OSD_UNIT_METRIC
-} osd_unit_t;
+} osd_unit_e;
 
-typedef struct {
-    uint16_t item_pos[OSD_MAX_ITEMS];
+typedef struct osd_profile_s {
+    uint16_t item_pos[OSD_ITEM_COUNT];
 
     // Alarms
     uint8_t rssi_alarm;
@@ -54,25 +54,13 @@ typedef struct {
     uint8_t video_system;
     uint8_t row_shiftdown;
 
-    osd_unit_t units;
+    osd_unit_e units;
 } osd_profile_t;
-
-typedef struct {
-    int16_t max_speed;
-    int16_t min_voltage; // /10
-    int16_t max_current; // /10
-    int16_t min_rssi;
-    int16_t max_altitude;
-} statistic_t;
 
 void updateOsd(uint32_t currentTime);
 void osdInit(void);
 void resetOsdConfig(osd_profile_t *osdProfile);
 void osdResetAlarms(void);
-
-#ifdef CMS
-void osdCmsInit(displayPort_t *);
-#endif
 
 // Character coordinate and attributes
 

--- a/src/main/io/osd_max7456.h
+++ b/src/main/io/osd_max7456.h
@@ -1,5 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
-extern displayPort_t osd7456DisplayPort;
-
-void osd7456DisplayPortInit(void);
+displayPort_t *osd7456DisplayPortInit(void);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -945,7 +945,7 @@ const clivalue_t valueTable[] = {
 
 #ifdef OSD
     { "osd_video_system",           VAR_UINT8  | MASTER_VALUE, &masterConfig.osdProfile.video_system, .config.minmax = { 0, 2 } },
-    { "osd_row_shiftdown",             VAR_UINT8  | MASTER_VALUE, &masterConfig.osdProfile.row_shiftdown, .config.minmax = { 0, 1 } },
+    { "osd_row_shiftdown",          VAR_UINT8  | MASTER_VALUE, &masterConfig.osdProfile.row_shiftdown, .config.minmax = { 0, 1 } },
     { "osd_units",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.osdProfile.units, .config.lookup = { TABLE_UNIT } },
 
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, &masterConfig.osdProfile.rssi_alarm, .config.minmax = { 0, 100 } },

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -463,7 +463,7 @@ void init(void)
 
 #ifdef CANVAS
     if (feature(FEATURE_CANVAS)) {
-        canvasInit();
+        cmsDisplayPortRegister(canvasInit());
     }
 #endif
 

--- a/src/main/msp/msp.h
+++ b/src/main/msp/msp.h
@@ -35,4 +35,3 @@ typedef struct mspPacket_s {
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.
 typedef mspResult_e (*mspProcessCommandFnPtr)(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
-typedef void (*mspPushCommandFnPtr)(mspPacket_t *push, uint8_t *, int);

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -66,5 +66,5 @@ void mspSerialInit(void);
 void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessCommandFnPtr mspProcessCommandFn);
 void mspSerialAllocatePorts(void);
 void mspSerialReleasePortIfAllocated(struct serialPort_s *serialPort);
-void mspSerialPush(uint8_t cmd, uint8_t *data, int datalen);
+int mspSerialPush(uint8_t cmd, const uint8_t *data, int datalen);
 uint32_t mspSerialTxBytesFree(void);

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -1,4 +1,3 @@
-#define USE_DPRINTF
 /*
  * This file is part of Cleanflight.
  *

--- a/src/main/target/OMNIBUS/target.mk
+++ b/src/main/target/OMNIBUS/target.mk
@@ -9,17 +9,8 @@ TARGET_SRC = \
             drivers/compass_ak8963.c \
             drivers/compass_ak8975.c \
             drivers/compass_hmc5883l.c \
+            drivers/max7456.c \
             drivers/serial_usb_vcp.c \
             drivers/transponder_ir.c \
             drivers/transponder_ir_stm32f30x.c \
-            io/transponder_ir.c \
-            drivers/max7456.c \
-            io/osd.c \
-            io/osd_max7456.c \
-            io/canvas.c \
-            io/cms.c \
-            io/cms_builtin.c \
-            io/cms_imu.c \
-            io/cms_blackbox.c \
-            io/cms_vtx.c \
-            io/cms_ledstrip.c
+            io/transponder_ir.c

--- a/src/main/target/OMNIBUSF4/target.mk
+++ b/src/main/target/OMNIBUSF4/target.mk
@@ -5,13 +5,5 @@ TARGET_SRC = \
             drivers/accgyro_spi_mpu6000.c \
             drivers/barometer_ms5611.c \
             drivers/compass_hmc5883l.c \
-            drivers/max7456.c \
-            io/osd.c \
-            io/osd_max7456.c \
-            io/cms.c \
-            io/cms_builtin.c \
-            io/cms_imu.c \
-            io/cms_blackbox.c \
-            io/cms_ledstrip.c \
-            io/canvas.c
+            drivers/max7456.c
 

--- a/src/main/target/SIRINFPV/target.mk
+++ b/src/main/target/SIRINFPV/target.mk
@@ -11,13 +11,4 @@ TARGET_SRC = \
             drivers/compass_hmc5883l.c \
             drivers/flash_m25p16.c \
             drivers/vtx_soft_spi_rtc6705.c \
-            drivers/max7456.c \
-            io/osd.c \
-            io/osd_max7456.c \
-            io/canvas.c \
-            io/cms.c \
-            io/cms_builtin.c \
-            io/cms_imu.c \
-            io/cms_blackbox.c \
-            io/cms_vtx.c \
-            io/cms_ledstrip.c
+            drivers/max7456.c

--- a/src/main/target/SPRACINGF3/target.mk
+++ b/src/main/target/SPRACINGF3/target.mk
@@ -8,12 +8,5 @@ TARGET_SRC = \
             drivers/barometer_bmp085.c \
             drivers/barometer_bmp280.c \
             drivers/compass_ak8975.c \
-            drivers/compass_hmc5883l.c \
-            io/canvas.c \
-            io/cms.c \
-            io/cms_builtin.c \
-            io/cms_imu.c \
-            io/cms_blackbox.c \
-            io/cms_vtx.c \
-            io/cms_ledstrip.c
+            drivers/compass_hmc5883l.c
 

--- a/src/main/target/STM32F3DISCOVERY/target.mk
+++ b/src/main/target/STM32F3DISCOVERY/target.mk
@@ -25,14 +25,4 @@ TARGET_SRC = \
             drivers/compass_ak8975.c \
             drivers/compass_hmc5883l.c \
             drivers/flash_m25p16.c \
-            drivers/max7456.c \
-            io/osd.c \
-            io/osd_max7456.c \
-            io/canvas.c \
-            io/cms.c \
-            io/cms_builtin.c \
-            io/cms_imu.c \
-            io/cms_blackbox.c \
-            io/cms_vtx.c \
-            io/cms_ledstrip.c
-
+            drivers/max7456.c


### PR DESCRIPTION
@jflyper , PR includes the following:

1. Addition of GPL headers
2. Improved const correctness
3. Moved CMS registration out of `displayPort` code - the `displayPort` should have no knowledge of CMS.
4. Moved CMS files out of `.mk` files into `makefile` - this makes it much easier to add new targets and goes with the general rule that `.mk` files should only contain device drivers.
5. Other minor cleanups

Can you merge this in, and then I'll do another PR to create the CMS directory and move the appropriate files into it.

We're almost there now.